### PR TITLE
Reusable indicator

### DIFF
--- a/score-http/pom.xml
+++ b/score-http/pom.xml
@@ -5,11 +5,7 @@
 
     <groupId>org.oagi</groupId>
     <artifactId>score-gateway</artifactId>
-<<<<<<< HEAD
-    <version>3.1.2</version>
-=======
     <version>3.2.0</version>
->>>>>>> v3.2
     <packaging>pom</packaging>
 
     <name>score-gateway</name>

--- a/score-http/score-http/pom.xml
+++ b/score-http/score-http/pom.xml
@@ -5,11 +5,7 @@
 
     <groupId>org.oagi</groupId>
     <artifactId>score-http</artifactId>
-<<<<<<< HEAD
-    <version>3.1.2</version>
-=======
     <version>3.2.0</version>
->>>>>>> v3.2
     <packaging>war</packaging>
 
     <name>score-http</name>
@@ -51,11 +47,7 @@
         <dependency>
             <groupId>org.oagi</groupId>
             <artifactId>score-service</artifactId>
-<<<<<<< HEAD
-            <version>3.1.2</version>
-=======
             <version>3.2.0</version>
->>>>>>> v3.2
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/bie_management/controller/BieListController.java
+++ b/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/bie_management/controller/BieListController.java
@@ -47,6 +47,7 @@ public class BieListController {
                                             @RequestParam(name = "updateStart", required = false) String updateStart,
                                             @RequestParam(name = "updateEnd", required = false) String updateEnd,
                                             @RequestParam(name = "ownedByDeveloper", required = false) Boolean ownedByDeveloper,
+                                            @RequestParam(name = "reusableIndicator", required = false) Boolean reusableIndicator,
                                             @RequestParam(name = "releaseIds", required = false) String releaseIds,
                                             @RequestParam(name = "sortActive") String sortActive,
                                             @RequestParam(name = "sortDirection") String sortDirection,
@@ -59,6 +60,7 @@ public class BieListController {
         request.setPropertyTerm(propertyTerm);
         request.setBusinessContext(businessContext);
         request.setAsccpManifestId(asccpManifestId);
+        request.setReusableIndicator(reusableIndicator);
         request.setAccess(StringUtils.hasLength(access) ? AccessPrivilege.valueOf(access) : null);
         request.setStates(StringUtils.hasLength(states) ?
                 Arrays.asList(states.split(",")).stream()

--- a/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/bie_management/data/BieList.java
+++ b/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/bie_management/data/BieList.java
@@ -28,6 +28,7 @@ public class BieList {
     private Date lastUpdateTimestamp;
     private String lastUpdateUser;
     private BieState state;
+    private Boolean reusableIndicator;
 
     private BigInteger sourceTopLevelAsbiepId;
     private BigInteger sourceReleaseId;

--- a/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/bie_management/data/BieListRequest.java
+++ b/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/bie_management/data/BieListRequest.java
@@ -31,6 +31,7 @@ public class BieListRequest {
     private Date updateEndDate;
     private PageRequest pageRequest = PageRequest.EMPTY_INSTANCE;
     private Boolean ownedByDeveloper;
+    private Boolean reusableIndicator;
     private String asccBccDen;
     private BigInteger bieId;
 }

--- a/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/bie_management/service/BieService.java
+++ b/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/bie_management/service/BieService.java
@@ -188,6 +188,7 @@ public class BieService {
                 .setUpdateDate(request.getUpdateStartDate(), request.getUpdateEndDate())
                 .setAccess(ULong.valueOf(requester.getAppUserId()), request.getAccess())
                 .setOwnedByDeveloper(request.getOwnedByDeveloper())
+                .setReusableIndicator(request.getReusableIndicator())
                 .setTenantBusinessCtx(requester.isAdmin(), userTenantIds)
                 .setSort(pageRequest.getSortActive(), pageRequest.getSortDirection())
                 .setOffset(pageRequest.getOffset(), pageRequest.getPageSize())
@@ -283,6 +284,7 @@ public class BieService {
                 .setAsccBccDen(request.getAsccBccDen())
                 .setAccess(ULong.valueOf(requester.getAppUserId()), request.getAccess())
                 .setOwnedByDeveloper(request.getOwnedByDeveloper())
+                .setReusableIndicator(request.getReusableIndicator())
                 .setSort(pageRequest.getSortActive(), pageRequest.getSortDirection())
                 .setOffset(pageRequest.getOffset(), pageRequest.getPageSize())
                 .fetchAsbieBbieInto(request.getTypes(), AsbieListRecord.class);

--- a/score-http/score-http/src/main/java/org/oagi/score/repo/BusinessInformationEntityRepository.java
+++ b/score-http/score-http/src/main/java/org/oagi/score/repo/BusinessInformationEntityRepository.java
@@ -498,6 +498,7 @@ public class BusinessInformationEntityRepository {
                     APP_USER.LOGIN_ID.as("owner"),
                     ASBIEP.BIZ_TERM,
                     ASBIEP.REMARK,
+                    ASCCP.REUSABLE_INDICATOR,
                     TOP_LEVEL_ASBIEP.LAST_UPDATE_TIMESTAMP,
                     APP_USER.as("updater").LOGIN_ID.as("last_update_user"),
                     TOP_LEVEL_ASBIEP.STATE,
@@ -750,6 +751,13 @@ public class BusinessInformationEntityRepository {
         public SelectBieListArguments setOwnedByDeveloper(Boolean ownedByDeveloper) {
             if (ownedByDeveloper != null) {
                 conditions.add(APP_USER.IS_DEVELOPER.eq(ownedByDeveloper ? (byte) 1 : 0));
+            }
+            return this;
+        }
+
+        public SelectBieListArguments setReusableIndicator(Boolean reusableIndicator) {
+            if (reusableIndicator != null) {
+                conditions.add(ASCCP.REUSABLE_INDICATOR.eq(reusableIndicator ? (byte) 1 : 0));
             }
             return this;
         }

--- a/score-http/score-repo-api/pom.xml
+++ b/score-http/score-repo-api/pom.xml
@@ -5,11 +5,7 @@
 
     <groupId>org.oagi</groupId>
     <artifactId>score-repo-api</artifactId>
-<<<<<<< HEAD
-    <version>3.1.2</version>
-=======
     <version>3.2.0</version>
->>>>>>> v3.2
     <packaging>jar</packaging>
 
     <name>score-repo-api</name>

--- a/score-http/score-repo/pom.xml
+++ b/score-http/score-repo/pom.xml
@@ -5,11 +5,7 @@
 
     <groupId>org.oagi</groupId>
     <artifactId>score-repo</artifactId>
-<<<<<<< HEAD
-    <version>3.1.2</version>
-=======
     <version>3.2.0</version>
->>>>>>> v3.2
     <packaging>jar</packaging>
 
     <name>score-repo</name>
@@ -37,11 +33,7 @@
         <dependency>
             <groupId>org.oagi</groupId>
             <artifactId>score-repo-api</artifactId>
-<<<<<<< HEAD
-            <version>3.1.2</version>
-=======
             <version>3.2.0</version>
->>>>>>> v3.2
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/score-http/score-service/pom.xml
+++ b/score-http/score-service/pom.xml
@@ -5,12 +5,7 @@
 
     <groupId>org.oagi</groupId>
     <artifactId>score-service</artifactId>
-<<<<<<< HEAD
-    <version>3.1.2</version>
-=======
     <version>3.2.0</version>
->>>>>>> v3.2
-
     <name>score-service</name>
     <description>Score Service</description>
 
@@ -42,11 +37,7 @@
         <dependency>
             <groupId>org.oagi</groupId>
             <artifactId>score-repo</artifactId>
-<<<<<<< HEAD
-            <version>3.1.2</version>
-=======
             <version>3.2.0</version>
->>>>>>> v3.2
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
- Addition of the "reusable indicator" field to the bie_list API request, which is a boolean that states whether or not a BIE is reusable.
- Fixes for bad pom.xml files which were contaminated with git merge markers