### PR TITLE
Add 'Transfer Ownership' submenu under 'Admin' menu.

### DIFF
--- a/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/account_management/controller/AccountController.java
+++ b/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/account_management/controller/AccountController.java
@@ -159,6 +159,14 @@ public class AccountController implements InitializingBean {
         return ResponseEntity.noContent().build();
     }
 
+    @RequestMapping(value = "/accounts/{id:[\\d]+}/transfer_ownership", method = RequestMethod.POST)
+    public ResponseEntity transferOwnership(
+            @PathVariable("id") BigInteger id,
+            @AuthenticationPrincipal AuthenticatedPrincipal user) {
+        accountService.transferOwnership(user, id);
+        return ResponseEntity.accepted().build();
+    }
+
     @RequestMapping(value = "/oauth2/logout", method = RequestMethod.GET)
     public void oauth2Logout(@AuthenticationPrincipal AuthenticatedPrincipal user,
                              HttpServletRequest request,

--- a/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/account_management/service/AccountService.java
+++ b/score-http/score-http/src/main/java/org/oagi/score/gateway/http/api/account_management/service/AccountService.java
@@ -1,8 +1,10 @@
 package org.oagi.score.gateway.http.api.account_management.service;
 
 import org.jooq.DSLContext;
+import org.jooq.impl.TableImpl;
 import org.jooq.types.ULong;
 import org.oagi.score.gateway.http.configuration.security.SessionService;
+import org.oagi.score.repo.api.impl.jooq.entity.Tables;
 import org.oagi.score.repo.api.impl.jooq.entity.tables.records.AppUserRecord;
 import org.oagi.score.service.common.data.AppUser;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +14,18 @@ import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.math.BigInteger;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static org.oagi.score.repo.api.impl.jooq.entity.tables.AppUser.APP_USER;
+import static org.springframework.util.ReflectionUtils.getField;
+import static org.springframework.util.ReflectionUtils.handleReflectionException;
 
 
 @Service
@@ -55,6 +67,67 @@ public class AccountService {
         if (!enabled) {
             sessionService.invalidateByUsername(targetAppUser.getLoginId());
         }
+    }
+
+    @Transactional
+    public void transferOwnership(AuthenticatedPrincipal user, BigInteger targetUserId) {
+        AppUser requester = sessionService.getAppUserByUsername(user);
+        if (!requester.isAdmin()) {
+            throw new InsufficientAuthenticationException(
+                    messages.getMessage(
+                            "ExceptionTranslationFilter.insufficientAuthentication",
+                            "Full authentication is required to access this resource"));
+        }
+
+        AppUserRecord targetAppUser = dslContext.selectFrom(APP_USER)
+                .where(APP_USER.APP_USER_ID.eq(ULong.valueOf(targetUserId)))
+                .fetchOptional().orElse(null);
+        if (targetAppUser == null) {
+            throw new IllegalArgumentException();
+        }
+
+        doWithDeclaredFields(Tables.class, field -> {
+            TableImpl<?> tableImpl = (TableImpl<?>) field.getObject();
+            boolean hasOwnerUserId;
+            try {
+                hasOwnerUserId = tableImpl.getClass().getDeclaredField("OWNER_USER_ID") != null;
+            } catch (NoSuchFieldException e) {
+                return;
+            }
+
+            if (hasOwnerUserId) {
+                dslContext.execute("UPDATE `" + tableImpl.getName() + "` SET `owner_user_id` = ? WHERE `owner_user_id` = ?",
+                        ULong.valueOf(requester.getAppUserId()), targetAppUser.getAppUserId());
+            }
+        }, field -> field.getObject() != null && field.getObject() instanceof TableImpl<?>);
+    }
+
+    private void doWithDeclaredFields(Class<?> clazz, Consumer<FieldContainer> callback, Predicate<FieldContainer> filter) {
+        for (Field field : clazz.getDeclaredFields()) {
+            Object obj = getField(field, clazz);
+            FieldContainer container = new FieldContainer() {
+                @Override
+                public Field getField() {
+                    return field;
+                }
+                @Override
+                public Object getObject() {
+                    return obj;
+                }
+            };
+
+            if (filter.test(container)) {
+                callback.accept(container);
+            }
+        }
+    }
+
+    private interface FieldContainer {
+
+        public Field getField();
+
+        public Object getObject();
+
     }
 
 }

--- a/score-web/src/app/account-management/account-management.module.ts
+++ b/score-web/src/app/account-management/account-management.module.ts
@@ -23,6 +23,7 @@ import {TenantListService} from './domain/tenant-list.service';
 import {TenantUserDetailComponent} from './tenant-user-detail/tenant-user-detail.component';
 import {TenantCreateComponent} from './tenant-create/tenant-create.component';
 import {UpdateTenantComponent} from './tenant-update/tenant-update.component';
+import {TransferOwnershipListComponent} from './take-ownership-list/transfer-ownership-list.component';
 
 
 const routes: Routes = [
@@ -34,6 +35,11 @@ const routes: Routes = [
   {
     path: 'account/create',
     component: AccountCreateComponent,
+    canActivate: [CanActivateAdmin]
+  },
+  {
+    path: 'account/transfer_ownership',
+    component: TransferOwnershipListComponent,
     canActivate: [CanActivateAdmin]
   },
   {
@@ -93,6 +99,7 @@ const routes: Routes = [
     PendingDetailComponent,
     PendingListComponent,
     AccountListDialogComponent,
+    TransferOwnershipListComponent,
     TenantListComponent,
     TenantBusinessCtxDetailComponent,
     TenantUserDetailComponent,

--- a/score-web/src/app/account-management/domain/account-list.service.ts
+++ b/score-web/src/app/account-management/domain/account-list.service.ts
@@ -107,12 +107,18 @@ export class AccountListService implements OnInit {
       });
     }
   }
+
   link(pending: PendingAccount, account: AccountList): Observable<any> {
     return this.http.post('/api/pending/link/' + pending.appOauth2UserId, {
-      appUserId: account.appUserId});
+      appUserId: account.appUserId
+    });
   }
 
   setEnable(account: AccountList, val: boolean): Observable<any> {
     return this.http.post('/api/accounts/' + account.appUserId + '/' + ((val) ? 'enable' : 'disable'), {});
+  }
+
+  transferOwnership(account: AccountList): Observable<any> {
+    return this.http.post('/api/accounts/' + account.appUserId + '/transfer_ownership', {});
   }
 }

--- a/score-web/src/app/account-management/take-ownership-list/transfer-ownership-list.component.html
+++ b/score-web/src/app/account-management/take-ownership-list/transfer-ownership-list.component.html
@@ -1,0 +1,135 @@
+<div class="context-section">
+  <div class="pl-2 pr-2">
+    <mat-toolbar class="bg-white">
+      <span class="title">{{ title }}</span>
+      <span class="flex-11-auto"></span>
+      <button mat-raised-button class="ml-2" color="primary" [disabled]="!selection.hasValue()"
+              (click)="transferOwnership(selection.selected[0])">
+        Transfer Ownership
+      </button>
+    </mat-toolbar>
+  </div>
+
+  <mat-card class="pt-3">
+    <mat-card class="search-box">
+      <mat-card-content class="mat-card-container">
+        <div class="container-fluid" style="padding: 0;">
+          <div class="row">
+            <div class="col-md-2 col-sm-12">
+              <mat-form-field>
+                <input matInput [(ngModel)]="request.filters.loginId"
+                       (ngModelChange)="onChange('filters.loginId', request.filters.loginId)"
+                       (keyup.enter)="this.paginator.pageIndex = 0; this.loadAccounts();"
+                       placeholder="Login ID">
+              </mat-form-field>
+            </div>
+            <div class="col-md-2 col-sm-12">
+              <mat-form-field>
+                <input matInput [(ngModel)]="request.filters.name"
+                       (ngModelChange)="onChange('filters.name', request.filters.name)"
+                       (keyup.enter)="this.paginator.pageIndex = 0; this.loadAccounts();"
+                       placeholder="Name">
+              </mat-form-field>
+            </div>
+            <div class="col-md-2 col-sm-12">
+              <mat-form-field>
+                <input matInput [(ngModel)]="request.filters.organization"
+                       (ngModelChange)="onChange('filters.organization', request.filters.organization)"
+                       (keyup.enter)="this.paginator.pageIndex = 0; this.loadAccounts();"
+                       placeholder="Organization">
+              </mat-form-field>
+            </div>
+            <div class="col-md-2 col-sm-12">
+              <mat-form-field>
+                <mat-label>Status</mat-label>
+                <mat-select [(ngModel)]="request.filters.status" multiple>
+                  <mat-option [value]="'enable'">
+                    Enable
+                  </mat-option>
+                  <mat-option [value]="'disable'">
+                    Disable
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+          </div>
+        </div>
+      </mat-card-content>
+      <mat-card-actions>
+        <button mat-raised-button color="primary" type="submit"
+                (click)="this.paginator.pageIndex = 0; this.loadAccounts();">
+          <mat-icon>search</mat-icon>
+          Search
+        </button>
+      </mat-card-actions>
+    </mat-card>
+
+    <mat-card-content class="mat-card-container">
+      <div class="loading-container" *ngIf="loading">
+        <mat-spinner [diameter]="40"></mat-spinner>
+      </div>
+      <div class="mat-elevation-z1">
+        <table mat-table
+               matSort [matSortActive]="sort.active" [matSortDirection]="sort.direction" [matSortStart]="'desc'"
+               [dataSource]="dataSource">
+
+          <!-- Checkbox Column -->
+          <ng-container matColumnDef="select">
+            <th mat-header-cell *matHeaderCellDef>
+            </th>
+            <td mat-cell *matCellDef="let row">
+              <mat-checkbox (click)="$event.stopPropagation()"
+                            (change)="$event ? toggle(row) : null"
+                            [checked]="isSelected(row)">
+              </mat-checkbox>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="loginId">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header> Login ID</th>
+            <td mat-cell *matCellDef="let element">
+              <a routerLink="{{ element.appUserId }}"> {{ element.loginId }} </a>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="role">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header> Role</th>
+            <td mat-cell *matCellDef="let element" [ngSwitch]="element.developer">
+              <span *ngSwitchCase="true">Developer</span>
+              <span *ngSwitchCase="false">End User</span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef> Name</th>
+            <td mat-cell *matCellDef="let element">
+              {{ element.name }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="organization">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header> Organization</th>
+            <td mat-cell *matCellDef="let element">
+              {{ element.organization }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="status">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header> Status</th>
+            <td mat-cell *matCellDef="let element">
+              {{ (element.enabled) ? 'Enable' : 'Disable' }}
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+
+        <mat-paginator
+          [pageSizeOptions]="[10, 25, 50]"
+          (page)="onPageChange($event)"
+          showFirstLastButtons></mat-paginator>
+      </div>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/score-web/src/app/account-management/take-ownership-list/transfer-ownership-list.component.spec.ts
+++ b/score-web/src/app/account-management/take-ownership-list/transfer-ownership-list.component.spec.ts
@@ -1,0 +1,25 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {TransferOwnershipListComponent} from './transfer-ownership-list.component';
+
+describe('AccountListComponent', () => {
+  let component: TransferOwnershipListComponent;
+  let fixture: ComponentFixture<TransferOwnershipListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TransferOwnershipListComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TransferOwnershipListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/score-web/src/app/account-management/take-ownership-list/transfer-ownership-list.component.ts
+++ b/score-web/src/app/account-management/take-ownership-list/transfer-ownership-list.component.ts
@@ -1,0 +1,136 @@
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {MatTableDataSource} from '@angular/material/table';
+import {AccountList, AccountListRequest} from '../domain/accounts';
+import {MatSort, SortDirection} from '@angular/material/sort';
+import {MatPaginator, PageEvent} from '@angular/material/paginator';
+import {AuthService} from '../../authentication/auth.service';
+import {AccountListService} from '../domain/account-list.service';
+import {Location} from '@angular/common';
+import {ActivatedRoute, Router} from '@angular/router';
+import {PageRequest} from '../../basis/basis';
+import {finalize} from 'rxjs/operators';
+import {SelectionModel} from '@angular/cdk/collections';
+import {ConfirmDialogService} from '../../common/confirm-dialog/confirm-dialog.service';
+import {MatSnackBar} from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'score-transfer-ownership-list',
+  templateUrl: './transfer-ownership-list.component.html',
+  styleUrls: ['./transfer-ownership-list.component.css']
+})
+export class TransferOwnershipListComponent implements OnInit {
+
+  title = 'Transfer Ownership';
+  displayedColumns: string[] = [
+    'select', 'loginId', 'role', 'name', 'organization', 'status'
+  ];
+  selection = new SelectionModel<AccountList>(false, []);
+  dataSource = new MatTableDataSource<AccountList>();
+  loading = false;
+
+  request: AccountListRequest;
+
+  @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
+
+  constructor(private auth: AuthService,
+              private service: AccountListService,
+              private confirmDialogService: ConfirmDialogService,
+              private snackBar: MatSnackBar,
+              private location: Location,
+              private router: Router,
+              private route: ActivatedRoute) {
+  }
+
+  ngOnInit() {
+    this.request = new AccountListRequest(this.route.snapshot.queryParamMap,
+      new PageRequest('name', 'asc', 0, 10));
+
+    this.paginator.pageIndex = this.request.page.pageIndex;
+    this.paginator.pageSize = this.request.page.pageSize;
+    this.paginator.length = 0;
+
+    this.sort.active = this.request.page.sortActive;
+    this.sort.direction = this.request.page.sortDirection as SortDirection;
+    this.sort.sortChange.subscribe(() => {
+      this.paginator.pageIndex = 0;
+      this.loadAccounts();
+    });
+
+    this.loadAccounts(true);
+  }
+
+  onPageChange(event: PageEvent) {
+    this.loadAccounts();
+  }
+
+  onChange(property?: string, source?) {
+  }
+
+  loadAccounts(isInit?: boolean) {
+    this.loading = true;
+
+    this.request.page = new PageRequest(
+      this.sort.active, this.sort.direction,
+      this.paginator.pageIndex, this.paginator.pageSize);
+
+    this.service.getAccountsList(this.request).pipe(
+      finalize(() => {
+        this.loading = false;
+      })
+    ).subscribe(resp => {
+      this.paginator.length = resp.length;
+      this.paginator.pageIndex = resp.page;
+      this.dataSource.data = resp.list;
+      if (!isInit) {
+        this.location.replaceState(this.router.url.split('?')[0], this.request.toQuery());
+      }
+    }, error => {
+      this.dataSource.data = [];
+    });
+  }
+
+  toggle(row: AccountList) {
+    if (this.isSelected(row)) {
+      this.selection.deselect(row);
+    } else {
+      this.select(row);
+    }
+  }
+
+  isSelected(row: AccountList) {
+    return this.selection.isSelected(row);
+  }
+
+  select(row: AccountList) {
+    this.selection.select(row);
+  }
+
+  transferOwnership(row: AccountList): void {
+    const dialogConfig = this.confirmDialogService.newConfig();
+    dialogConfig.data.header = 'Transfer Ownership?';
+    dialogConfig.data.content = [
+      'Are you sure you want to transfer ownership of all components from the user ',
+      '\'' + row.name + ' (' + row.loginId + ')\' to you? This action is irreversible.'
+    ];
+    dialogConfig.data.action = 'Transfer';
+
+    this.confirmDialogService.open(dialogConfig).afterClosed()
+      .subscribe(result => {
+        if (result) {
+          this.loading = true;
+          this.service.transferOwnership(row).subscribe(_ => {
+            this.loading = false;
+            this.selection.clear();
+
+            this.snackBar.open('Transferred', '', {
+              duration: 3000,
+            });
+          }, error => {
+            this.loading = false;
+          });
+        }
+      });
+  }
+
+}

--- a/score-web/src/app/basis/navbar/navbar.component.html
+++ b/score-web/src/app/basis/navbar/navbar.component.html
@@ -78,6 +78,7 @@
     <mat-menu #adminMenu="matMenu" [overlapTrigger]="false">
       <ng-template matMenuContent>
         <button mat-menu-item routerLink="account">Accounts</button>
+        <button mat-menu-item routerLink="account/transfer_ownership">Transfer Ownership</button>
         <button mat-menu-item routerLink="account/pending">Pending SSO</button>
         <button *ngIf="isTenantEnabled" mat-menu-item routerLink="tenant">Tenant</button>
       </ng-template>


### PR DESCRIPTION
As we discussed before, I added the 'Transfer Ownership' submenu under the 'Admin' menu.
<img width="667" alt="Screenshot 2023-11-20 at 2 01 02 PM" src="https://github.com/OAGi/Score/assets/16102116/9a332cc6-6a78-40e2-9c1d-aa8abf4e0719">

When the admin user selects the checkbox for the target user's name, the 'Transfer Ownership' button will appear on the top right side of the screen.
<img width="1332" alt="Screenshot 2023-11-20 at 2 05 18 PM" src="https://github.com/OAGi/Score/assets/16102116/89f4b543-e19e-43f8-bc4e-afc317f5453d">

Clicking this button will display the following warning message.
<img width="589" alt="Screenshot 2023-11-20 at 2 06 50 PM" src="https://github.com/OAGi/Score/assets/16102116/0b096bf7-0330-4a96-859b-6e069de11022">

If the admin user clicks the 'Transfer' button, it will transfer ownership of all components from the selected user to the admin user.